### PR TITLE
feat: add python client for hasicorp vault (hvac) and fix ansible to 2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/vmware/vsphere-automation-sdk-python.git@7.0.0.0#egg=vsphere-automation-sdk
-ansible~=2.9
+ansible~=2.9.16
 awscli==1.16.248
 boto3==1.9.238
 boto==2.49.0
@@ -7,6 +7,7 @@ botocore==1.12.238
 cryptography~=2.8.0
 dbus-python==1.2.16
 dnspython==1.16.0
+hvac==0.10.6
 lxml==4.6.2
 netaddr==0.7.19
 openshift==0.11.0


### PR DESCRIPTION
# What ?
* Add python client for hashicorp vault ( hvac ) - required to use the [hashi_vault](https://docs.ansible.com/ansible/2.9/plugins/lookup/hashi_vault.html) lookup plugin.
* Specify version to compatible with ~=2.9.16, 2.10 introduces changes if only ~=2.9  is specified.